### PR TITLE
Add support for custom PSR-17 implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
         - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text" XDEBUG_MODE=coverage
         - php: 8.0
+        - php: 8.0
+          env: VENDORS=minimal
 
           # Latest commit to master
         - php: 7.4
@@ -38,7 +40,7 @@ matrix:
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
-    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
+    - if ! [ $DEPENDENCIES == "minimal" ]; then composer remove --dev --no-update nyholm/psr7 laminas/laminas-diactoros; fi;
 
 install:
     # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355

--- a/ArgumentValueResolver/PsrServerRequestResolver.php
+++ b/ArgumentValueResolver/PsrServerRequestResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver;
 
 use Psr\Http\Message\MessageInterface;

--- a/Bundle/DependencyInjection/Configuration.php
+++ b/Bundle/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\PsrHttpMessage\Bundle\DependencyInjection;
 use Laminas\Diactoros\RequestFactory;
 use Laminas\Diactoros\ServerRequestFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -33,7 +34,7 @@ final class Configuration implements ConfigurationInterface
                 ->children()
                     ->enumNode('implementation')
                         ->info('The PSR-7 implementation to use. By default, the bundle will configure the Nyholm implementation if it\'s available.')
-                        ->values(['nyholm', 'diactoros'])
+                        ->values(['nyholm', 'diactoros', 'custom'])
                         ->defaultValue(class_exists(Psr17Factory::class) || !class_exists(ServerRequestFactory::class) ? 'nyholm' : 'diactoros')
                         ->validate()
                             ->ifTrue(function ($value) {
@@ -44,6 +45,11 @@ final class Configuration implements ConfigurationInterface
                             ->ifTrue(function ($value) {
                                 return 'diactoros' === $value && !class_exists(RequestFactory::class);
                             })->thenInvalid('Cannot configure Diactoros. Try running "composer require laminas/laminas-diactoros".')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($value) {
+                                return 'custom' === $value && !class_exists(ServerRequestFactoryInterface::class);
+                            })->thenInvalid('There is no PSR-17 implementation. Try running "composer require nyholm/psr7".')
                         ->end()
                     ->end()
                 ->end()

--- a/Bundle/DependencyInjection/Configuration.php
+++ b/Bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PsrHttpMessage\Bundle\DependencyInjection;
+
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('psr_http_message');
+        $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode->children()
+            ->arrayNode('message_factories')
+                ->{class_exists(Psr17Factory::class) || class_exists(ServerRequestFactory::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                ->children()
+                    ->enumNode('implementation')
+                        ->info('The PSR-7 implementation to use. By default, the bundle will configure the Nyholm implementation if it\'s available.')
+                        ->values(['nyholm', 'diactoros'])
+                        ->defaultValue(class_exists(Psr17Factory::class) || !class_exists(ServerRequestFactory::class) ? 'nyholm' : 'diactoros')
+                        ->validate()
+                            ->ifTrue(function ($value) {
+                                return 'nyholm' === $value && !class_exists(Psr17Factory::class);
+                            })->thenInvalid('Cannot configure Nyholm\'s PSR-7 implementation. Try running "composer require nyholm/psr7".')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($value) {
+                                return 'diactoros' === $value && !class_exists(RequestFactory::class);
+                            })->thenInvalid('Cannot configure Diactoros. Try running "composer require laminas/laminas-diactoros".')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('message_converters')
+                ->info('Converters that enable controllers to operate on PSR-7 messages')
+                ->canBeEnabled()
+            ->end()
+            ->integerNode('response_buffer')
+                ->info('The maximum output buffering size for each iteration when sending the response')
+                ->min(1)
+                ->defaultValue(16372)
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/Bundle/DependencyInjection/PsrHttpMessageExtension.php
+++ b/Bundle/DependencyInjection/PsrHttpMessageExtension.php
@@ -11,7 +11,14 @@
 
 namespace Symfony\Bridge\PsrHttpMessage\Bundle\DependencyInjection;
 
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -19,8 +26,10 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 /**
  * @author Alexander M. Turek <me@derrabus.de>
  */
-final class PsrHttpMessageExtension extends Extension
+final class PsrHttpMessageExtension extends Extension implements CompilerPassInterface
 {
+    private $messageFactoriesImplementation = false;
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
@@ -35,7 +44,8 @@ final class PsrHttpMessageExtension extends Extension
             $loader->load('message_converters.php');
         }
 
-        switch ($config['message_factories']['enabled'] ? $config['message_factories']['implementation'] : 'disabled') {
+        $this->messageFactoriesImplementation = $config['message_factories']['enabled'] ? $config['message_factories']['implementation'] : 'disabled';
+        switch ($this->messageFactoriesImplementation) {
             case 'nyholm':
                 $loader->load('nyholm.php');
                 $loader->load('psr_factories.php');
@@ -44,9 +54,40 @@ final class PsrHttpMessageExtension extends Extension
                 $loader->load('diactoros.php');
                 $loader->load('psr_factories.php');
                 break;
+            case 'custom':
+                $loader->load('psr17_aliases.php');
+                $loader->load('psr_factories.php');
+                break;
             default:
                 $container->removeDefinition('psr_http_message.server_request_resolver');
                 break;
+        }
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $this->processPsr17FactoriesAliases($container);
+    }
+
+    private function processPsr17FactoriesAliases(ContainerBuilder $container): void
+    {
+        if ('disabled' === $this->messageFactoriesImplementation) {
+            return;
+        }
+
+        $psr17Interfaces = [
+            RequestFactoryInterface::class => 'psr_http_message.psr.request_factory',
+            ResponseFactoryInterface::class => 'psr_http_message.psr.response_factory',
+            ServerRequestFactoryInterface::class => 'psr_http_message.psr.server_request_factory',
+            StreamFactoryInterface::class => 'psr_http_message.psr.stream_factory',
+            UploadedFileFactoryInterface::class => 'psr_http_message.psr.uploaded_file_factory',
+            UriFactoryInterface::class => 'psr_http_message.psr.uri_factory',
+        ];
+
+        foreach ($psr17Interfaces as $interface => $service) {
+            if (!$container->has($interface) && 'custom' !== $this->messageFactoriesImplementation) {
+                $container->setAlias($interface, $service);
+            }
         }
     }
 }

--- a/Bundle/DependencyInjection/PsrHttpMessageExtension.php
+++ b/Bundle/DependencyInjection/PsrHttpMessageExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PsrHttpMessage\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class PsrHttpMessageExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
+        $loader->load('http_foundation.php');
+
+        $configuration = $this->getConfiguration($configs, $container);
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('psr_http_message.response_buffer', $config['response_buffer']);
+
+        if ($config['message_converters']['enabled']) {
+            $loader->load('message_converters.php');
+        }
+
+        switch ($config['message_factories']['enabled'] ? $config['message_factories']['implementation'] : 'disabled') {
+            case 'nyholm':
+                $loader->load('nyholm.php');
+                $loader->load('psr_factories.php');
+                break;
+            case 'diactoros':
+                $loader->load('diactoros.php');
+                $loader->load('psr_factories.php');
+                break;
+            default:
+                $container->removeDefinition('psr_http_message.server_request_resolver');
+                break;
+        }
+    }
+}

--- a/Bundle/PsrHttpMessageBundle.php
+++ b/Bundle/PsrHttpMessageBundle.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PsrHttpMessage\Bundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class PsrHttpMessageBundle extends Bundle
+{
+}

--- a/Bundle/Resources/config/diactoros.php
+++ b/Bundle/Resources/config/diactoros.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\UploadedFileFactory;
+use Laminas\Diactoros\UriFactory;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('psr_http_message.diactoros.request_factory', RequestFactory::class)
+        ->set('psr_http_message.diactoros.response_factory', ResponseFactory::class)
+        ->set('psr_http_message.diactoros.server_request_factory', ServerRequestFactory::class)
+        ->set('psr_http_message.diactoros.stream_factory', StreamFactory::class)
+        ->set('psr_http_message.diactoros.uploaded_file_factory', UploadedFileFactory::class)
+        ->set('psr_http_message.diactoros.uri_factory', UriFactory::class)
+
+        ->alias('psr_http_message.psr.request_factory', 'psr_http_message.diactoros.request_factory')
+        ->alias('psr_http_message.psr.response_factory', 'psr_http_message.diactoros.response_factory')
+        ->alias('psr_http_message.psr.server_request_factory', 'psr_http_message.diactoros.server_request_factory')
+        ->alias('psr_http_message.psr.stream_factory', 'psr_http_message.diactoros.stream_factory')
+        ->alias('psr_http_message.psr.uploaded_file_factory', 'psr_http_message.diactoros.uploaded_file_factory')
+        ->alias('psr_http_message.psr.uri_factory', 'psr_http_message.diactoros.uri_factory')
+    ;
+};

--- a/Bundle/Resources/config/http_foundation.php
+++ b/Bundle/Resources/config/http_foundation.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('psr_http_message.http_foundation_factory', HttpFoundationFactory::class)
+            ->args(['%psr_http_message.response_buffer%'])
+
+        ->alias(HttpFoundationFactoryInterface::class, 'psr_http_message.http_foundation_factory')
+    ;
+};

--- a/Bundle/Resources/config/message_converters.php
+++ b/Bundle/Resources/config/message_converters.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
+use Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener;
+use Symfony\Component\DependencyInjection\Reference;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('psr_http_message.response_listener', PsrResponseListener::class)
+            ->args([new Reference('psr_http_message.http_foundation_factory')])
+            ->tag('kernel.event_subscriber')
+
+        ->set('psr_http_message.server_request_resolver', PsrServerRequestResolver::class)
+            ->args([new Reference('psr_http_message.psr_http_factory')])
+            ->tag('controller.argument_value_resolver')
+    ;
+};

--- a/Bundle/Resources/config/nyholm.php
+++ b/Bundle/Resources/config/nyholm.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('psr_http_message.nyholm.factory', Psr17Factory::class)
+
+        ->alias('psr_http_message.psr.request_factory', 'psr_http_message.nyholm.factory')
+        ->alias('psr_http_message.psr.response_factory', 'psr_http_message.nyholm.factory')
+        ->alias('psr_http_message.psr.server_request_factory', 'psr_http_message.nyholm.factory')
+        ->alias('psr_http_message.psr.stream_factory', 'psr_http_message.nyholm.factory')
+        ->alias('psr_http_message.psr.uploaded_file_factory', 'psr_http_message.nyholm.factory')
+        ->alias('psr_http_message.psr.uri_factory', 'psr_http_message.nyholm.factory')
+    ;
+};

--- a/Bundle/Resources/config/psr17_aliases.php
+++ b/Bundle/Resources/config/psr17_aliases.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->alias('psr_http_message.psr.request_factory', RequestFactoryInterface::class)
+        ->alias('psr_http_message.psr.response_factory', ResponseFactoryInterface::class)
+        ->alias('psr_http_message.psr.server_request_factory', ServerRequestFactoryInterface::class)
+        ->alias('psr_http_message.psr.stream_factory', StreamFactoryInterface::class)
+        ->alias('psr_http_message.psr.uploaded_file_factory', UploadedFileFactoryInterface::class)
+        ->alias('psr_http_message.psr.uri_factory', UriFactoryInterface::class)
+    ;
+};

--- a/Bundle/Resources/config/psr_factories.php
+++ b/Bundle/Resources/config/psr_factories.php
@@ -11,12 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\ResponseFactoryInterface;
-use Psr\Http\Message\ServerRequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Message\UploadedFileFactoryInterface;
-use Psr\Http\Message\UriFactoryInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\DependencyInjection\Reference;
@@ -32,12 +26,5 @@ return static function (ContainerConfigurator $container) {
         ])
 
         ->alias(HttpMessageFactoryInterface::class, 'psr_http_message.psr_http_factory')
-
-        ->alias(RequestFactoryInterface::class, 'psr_http_message.psr.request_factory')
-        ->alias(ResponseFactoryInterface::class, 'psr_http_message.psr.response_factory')
-        ->alias(ServerRequestFactoryInterface::class, 'psr_http_message.psr.server_request_factory')
-        ->alias(StreamFactoryInterface::class, 'psr_http_message.psr.stream_factory')
-        ->alias(UploadedFileFactoryInterface::class, 'psr_http_message.psr.uploaded_file_factory')
-        ->alias(UriFactoryInterface::class, 'psr_http_message.psr.uri_factory')
     ;
 };

--- a/Bundle/Resources/config/psr_factories.php
+++ b/Bundle/Resources/config/psr_factories.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('psr_http_message.psr_http_factory', PsrHttpFactory::class)
+        ->args([
+            new Reference('psr_http_message.psr.server_request_factory'),
+            new Reference('psr_http_message.psr.stream_factory'),
+            new Reference('psr_http_message.psr.uploaded_file_factory'),
+            new Reference('psr_http_message.psr.response_factory'),
+        ])
+
+        ->alias(HttpMessageFactoryInterface::class, 'psr_http_message.psr_http_factory')
+
+        ->alias(RequestFactoryInterface::class, 'psr_http_message.psr.request_factory')
+        ->alias(ResponseFactoryInterface::class, 'psr_http_message.psr.response_factory')
+        ->alias(ServerRequestFactoryInterface::class, 'psr_http_message.psr.server_request_factory')
+        ->alias(StreamFactoryInterface::class, 'psr_http_message.psr.stream_factory')
+        ->alias(UploadedFileFactoryInterface::class, 'psr_http_message.psr.uploaded_file_factory')
+        ->alias(UriFactoryInterface::class, 'psr_http_message.psr.uri_factory')
+    ;
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+# 2.2.0 (TBA)
+
+  * Added a bundle that integrates the bridge into Symfony applications
+
 # 2.1.0 (2021-02-17)
 
   * Added a `PsrResponseListener` to automatically convert PSR-7 responses returned by controllers

--- a/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
+++ b/Tests/ArgumentValueResolver/PsrServerRequestResolverTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\PsrHttpMessage\Tests\ArgumentValueResolver;
 
 use PHPUnit\Framework\TestCase;

--- a/Tests/EventListener/PsrResponseListenerTest.php
+++ b/Tests/EventListener/PsrResponseListenerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\PsrHttpMessage\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;

--- a/Tests/Factory/PsrHttpFactoryTest.php
+++ b/Tests/Factory/PsrHttpFactoryTest.php
@@ -23,6 +23,10 @@ class PsrHttpFactoryTest extends AbstractHttpMessageFactoryTest
 {
     protected function buildHttpMessageFactory(): HttpMessageFactoryInterface
     {
+        if (!class_exists(Psr17Factory::class)) {
+            self::markTestSkipped('This test requires nyholm/psr7.');
+        }
+
         $factory = new Psr17Factory();
 
         return new PsrHttpFactory($factory, $factory, $factory, $factory);

--- a/Tests/Fixtures/App/Kernel.php
+++ b/Tests/Fixtures/App/Kernel.php
@@ -61,7 +61,7 @@ class Kernel extends SymfonyKernel
         $bundleConfig = [
             'message_converters' => ['enabled' => true],
         ];
-        if ('auto' !== $this->implementation) {
+        if ('auto' !== $this->implementation && 'minimal' !== $this->implementation) {
             $bundleConfig['message_factories'] = [
                 'enabled' => true,
                 'implementation' => $this->implementation,
@@ -72,8 +72,13 @@ class Kernel extends SymfonyKernel
 
         $container->services()
             ->set('logger', NullLogger::class)
-            ->set(PsrRequestController::class)->public()->autowire()
-            ->set(AllFactories::class)->public()->autowire()
         ;
+
+        if ('minimal' !== $this->implementation) {
+            $container->services()
+                ->set(PsrRequestController::class)->public()->autowire()
+                ->set(AllFactories::class)->public()->autowire()
+            ;
+        }
     }
 }

--- a/Tests/Fixtures/App/Kernel.php
+++ b/Tests/Fixtures/App/Kernel.php
@@ -2,19 +2,10 @@
 
 namespace Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Http\Message\ResponseFactoryInterface;
-use Psr\Http\Message\ServerRequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Log\NullLogger;
-use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
-use Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
-use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Bundle\PsrHttpMessageBundle;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Controller\PsrRequestController;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Service\AllFactories;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -25,14 +16,29 @@ class Kernel extends SymfonyKernel
 {
     use MicroKernelTrait;
 
+    private $implementation;
+
+    public function __construct(string $implementation)
+    {
+        $this->implementation = $implementation;
+
+        parent::__construct('test', true);
+    }
+
     public function registerBundles(): iterable
     {
         yield new FrameworkBundle();
+        yield new PsrHttpMessageBundle();
     }
 
     public function getProjectDir(): string
     {
         return __DIR__;
+    }
+
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir().'/'.$this->implementation;
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
@@ -52,25 +58,22 @@ class Kernel extends SymfonyKernel
             'test' => true,
         ]);
 
-        $container->services()
-            ->set('nyholm.psr_factory', Psr17Factory::class)
-            ->alias(ResponseFactoryInterface::class, 'nyholm.psr_factory')
-            ->alias(ServerRequestFactoryInterface::class, 'nyholm.psr_factory')
-            ->alias(StreamFactoryInterface::class, 'nyholm.psr_factory')
-            ->alias(UploadedFileFactoryInterface::class, 'nyholm.psr_factory')
-        ;
+        $bundleConfig = [
+            'message_converters' => ['enabled' => true],
+        ];
+        if ('auto' !== $this->implementation) {
+            $bundleConfig['message_factories'] = [
+                'enabled' => true,
+                'implementation' => $this->implementation,
+            ];
+        }
 
-        $container->services()
-            ->defaults()->autowire()->autoconfigure()
-            ->set(HttpFoundationFactoryInterface::class, HttpFoundationFactory::class)
-            ->set(HttpMessageFactoryInterface::class, PsrHttpFactory::class)
-            ->set(PsrResponseListener::class)
-            ->set(PsrServerRequestResolver::class)
-        ;
+        $container->extension('psr_http_message', $bundleConfig);
 
         $container->services()
             ->set('logger', NullLogger::class)
             ->set(PsrRequestController::class)->public()->autowire()
+            ->set(AllFactories::class)->public()->autowire()
         ;
     }
 }

--- a/Tests/Fixtures/App/Kernel44.php
+++ b/Tests/Fixtures/App/Kernel44.php
@@ -2,19 +2,10 @@
 
 namespace Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Http\Message\ResponseFactoryInterface;
-use Psr\Http\Message\ServerRequestFactoryInterface;
-use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Log\NullLogger;
-use Symfony\Bridge\PsrHttpMessage\ArgumentValueResolver\PsrServerRequestResolver;
-use Symfony\Bridge\PsrHttpMessage\EventListener\PsrResponseListener;
-use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
-use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Bundle\PsrHttpMessageBundle;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Controller\PsrRequestController;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Service\AllFactories;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -26,14 +17,29 @@ class Kernel44 extends SymfonyKernel
 {
     use MicroKernelTrait;
 
+    private $implementation;
+
+    public function __construct(string $implementation)
+    {
+        $this->implementation = $implementation;
+
+        parent::__construct('test', true);
+    }
+
     public function registerBundles(): iterable
     {
         yield new FrameworkBundle();
+        yield new PsrHttpMessageBundle();
     }
 
     public function getProjectDir(): string
     {
         return __DIR__;
+    }
+
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir().'/'.$this->implementation;
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void
@@ -50,18 +56,20 @@ class Kernel44 extends SymfonyKernel
             'test' => true,
         ]);
 
-        $container->register('nyholm.psr_factory', Psr17Factory::class);
-        $container->setAlias(ResponseFactoryInterface::class, 'nyholm.psr_factory');
-        $container->setAlias(ServerRequestFactoryInterface::class, 'nyholm.psr_factory');
-        $container->setAlias(StreamFactoryInterface::class, 'nyholm.psr_factory');
-        $container->setAlias(UploadedFileFactoryInterface::class, 'nyholm.psr_factory');
+        $bundleConfig = [
+            'message_converters' => ['enabled' => true],
+        ];
+        if ('auto' !== $this->implementation) {
+            $bundleConfig['message_factories'] = [
+                'enabled' => true,
+                'implementation' => $this->implementation,
+            ];
+        }
 
-        $container->register(HttpFoundationFactoryInterface::class, HttpFoundationFactory::class)->setAutowired(true)->setAutoconfigured(true);
-        $container->register(HttpMessageFactoryInterface::class, PsrHttpFactory::class)->setAutowired(true)->setAutoconfigured(true);
-        $container->register(PsrResponseListener::class)->setAutowired(true)->setAutoconfigured(true);
-        $container->register(PsrServerRequestResolver::class)->setAutowired(true)->setAutoconfigured(true);
+        $container->loadFromExtension('psr_http_message', $bundleConfig);
 
         $container->register('logger', NullLogger::class);
         $container->register(PsrRequestController::class)->setPublic(true)->setAutowired(true);
+        $container->register(AllFactories::class)->setPublic(true)->setAutowired(true);
     }
 }

--- a/Tests/Fixtures/App/Kernel44.php
+++ b/Tests/Fixtures/App/Kernel44.php
@@ -59,7 +59,7 @@ class Kernel44 extends SymfonyKernel
         $bundleConfig = [
             'message_converters' => ['enabled' => true],
         ];
-        if ('auto' !== $this->implementation) {
+        if ('auto' !== $this->implementation && 'minimal' !== $this->implementation) {
             $bundleConfig['message_factories'] = [
                 'enabled' => true,
                 'implementation' => $this->implementation,
@@ -69,7 +69,10 @@ class Kernel44 extends SymfonyKernel
         $container->loadFromExtension('psr_http_message', $bundleConfig);
 
         $container->register('logger', NullLogger::class);
-        $container->register(PsrRequestController::class)->setPublic(true)->setAutowired(true);
-        $container->register(AllFactories::class)->setPublic(true)->setAutowired(true);
+
+        if ('minimal' !== $this->implementation) {
+            $container->register(PsrRequestController::class)->setPublic(true)->setAutowired(true);
+            $container->register(AllFactories::class)->setPublic(true)->setAutowired(true);
+        }
     }
 }

--- a/Tests/Fixtures/App/Service/AllFactories.php
+++ b/Tests/Fixtures/App/Service/AllFactories.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Service;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+
+final class AllFactories
+{
+    private $httpFoundationFactory;
+    private $httpMessageFactory;
+    private $requestFactory;
+    private $responseFactory;
+    private $serverRequestFactory;
+    private $streamFactory;
+    private $uploadedFileFactory;
+    private $uriFactory;
+
+    public function __construct(
+        HttpFoundationFactoryInterface $httpFoundationFactory,
+        HttpMessageFactoryInterface $httpMessageFactory,
+
+        RequestFactoryInterface $requestFactory,
+        ResponseFactoryInterface $responseFactory,
+        ServerRequestFactoryInterface $serverRequestFactory,
+        StreamFactoryInterface $streamFactory,
+        UploadedFileFactoryInterface $uploadedFileFactory,
+        UriFactoryInterface $uriFactory
+    ) {
+        $this->httpFoundationFactory = $httpFoundationFactory;
+        $this->httpMessageFactory = $httpMessageFactory;
+        $this->requestFactory = $requestFactory;
+        $this->responseFactory = $responseFactory;
+        $this->serverRequestFactory = $serverRequestFactory;
+        $this->streamFactory = $streamFactory;
+        $this->uploadedFileFactory = $uploadedFileFactory;
+        $this->uriFactory = $uriFactory;
+    }
+
+    public function getHttpFoundationFactory(): HttpFoundationFactoryInterface
+    {
+        return $this->httpFoundationFactory;
+    }
+
+    public function getHttpMessageFactory(): HttpMessageFactoryInterface
+    {
+        return $this->httpMessageFactory;
+    }
+
+    public function getRequestFactory(): RequestFactoryInterface
+    {
+        return $this->requestFactory;
+    }
+
+    public function getResponseFactory(): ResponseFactoryInterface
+    {
+        return $this->responseFactory;
+    }
+
+    public function getServerRequestFactory(): ServerRequestFactoryInterface
+    {
+        return $this->serverRequestFactory;
+    }
+
+    public function getStreamFactory(): StreamFactoryInterface
+    {
+        return $this->streamFactory;
+    }
+
+    public function getUploadedFileFactory(): UploadedFileFactoryInterface
+    {
+        return $this->uploadedFileFactory;
+    }
+
+    public function getUriFactory(): UriFactoryInterface
+    {
+        return $this->uriFactory;
+    }
+}

--- a/Tests/Functional/AutoControllerTest.php
+++ b/Tests/Functional/AutoControllerTest.php
@@ -25,6 +25,10 @@ final class AutoControllerTest extends ControllerTest
 
     protected static function getImplementation(): string
     {
+        if (!class_exists(Psr17Factory::class)) {
+            self::markTestSkipped('This test requires nyholm/psr7.');
+        }
+
         return 'auto';
     }
 }

--- a/Tests/Functional/AutoControllerTest.php
+++ b/Tests/Functional/AutoControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Functional;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Service\AllFactories;
+
+final class AutoControllerTest extends ControllerTest
+{
+    public function testImplementationIsNyholm()
+    {
+        self::bootKernel();
+
+        self::assertInstanceOf(Psr17Factory::class, self::$container->get(AllFactories::class)->getServerRequestFactory());
+    }
+
+    protected static function getImplementation(): string
+    {
+        return 'auto';
+    }
+}

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -1,16 +1,26 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\PsrHttpMessage\Tests\Functional;
 
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Kernel;
 use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Kernel44;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Alexander M. Turek <me@derrabus.de>
  */
-final class ControllerTest extends WebTestCase
+abstract class ControllerTest extends WebTestCase
 {
     public function testServerRequestAction()
     {
@@ -43,4 +53,15 @@ final class ControllerTest extends WebTestCase
     {
         return SymfonyKernel::VERSION_ID >= 50200 ? Kernel::class : Kernel44::class;
     }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        if (null === static::$class) {
+            static::$class = static::getKernelClass();
+        }
+
+        return new static::$class(static::getImplementation());
+    }
+
+    abstract protected static function getImplementation(): string;
 }

--- a/Tests/Functional/CovertTest.php
+++ b/Tests/Functional/CovertTest.php
@@ -36,12 +36,15 @@ class CovertTest extends TestCase
 {
     private $tmpDir;
 
-    protected function setUp(): void
+    public static function setUpBeforeClass(): void
     {
         if (!class_exists(Psr7Request::class)) {
-            $this->markTestSkipped('nyholm/psr7 is not installed.');
+            self::markTestSkipped('nyholm/psr7 is not installed.');
         }
+    }
 
+    protected function setUp(): void
+    {
         $this->tmpDir = sys_get_temp_dir();
     }
 

--- a/Tests/Functional/DiactorosControllerTest.php
+++ b/Tests/Functional/DiactorosControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Functional;
+
+use Laminas\Diactoros\ServerRequestFactory;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Service\AllFactories;
+
+final class DiactorosControllerTest extends ControllerTest
+{
+    public function testImplementationIsDiactoros()
+    {
+        self::bootKernel();
+
+        self::assertInstanceOf(ServerRequestFactory::class, self::$container->get(AllFactories::class)->getServerRequestFactory());
+    }
+
+    protected static function getImplementation(): string
+    {
+        return 'diactoros';
+    }
+}

--- a/Tests/Functional/DiactorosControllerTest.php
+++ b/Tests/Functional/DiactorosControllerTest.php
@@ -25,6 +25,10 @@ final class DiactorosControllerTest extends ControllerTest
 
     protected static function getImplementation(): string
     {
+        if (!class_exists(ServerRequestFactory::class)) {
+            self::markTestSkipped('This test requires nyholm/psr7.');
+        }
+
         return 'diactoros';
     }
 }

--- a/Tests/Functional/MinimalBundleTest.php
+++ b/Tests/Functional/MinimalBundleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Functional;
+
+use Laminas\Diactoros\ServerRequestFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Kernel;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Kernel44;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class MinimalBundleTest extends KernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (class_exists(Psr17Factory::class) || class_exists(ServerRequestFactory::class)) {
+            self::markTestSkipped('This test requires that no PSR-7 implementation in installed.');
+        }
+    }
+
+    public function testMinimalBundle()
+    {
+        self::bootKernel();
+
+        self::assertFalse(self::$container->has(HttpMessageFactoryInterface::class));
+        self::assertInstanceOf(HttpFoundationFactory::class, self::$container->get(HttpFoundationFactoryInterface::class));
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return SymfonyKernel::VERSION_ID >= 50200 ? Kernel::class : Kernel44::class;
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        if (null === static::$class) {
+            static::$class = static::getKernelClass();
+        }
+
+        return new static::$class('minimal');
+    }
+}

--- a/Tests/Functional/NyholmControllerTest.php
+++ b/Tests/Functional/NyholmControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PsrHttpMessage\Tests\Functional;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Tests\Fixtures\App\Service\AllFactories;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class NyholmControllerTest extends ControllerTest
+{
+    public function testImplementationIsNyholm()
+    {
+        self::bootKernel();
+
+        self::assertInstanceOf(Psr17Factory::class, self::$container->get(AllFactories::class)->getServerRequestFactory());
+    }
+
+    protected static function getImplementation(): string
+    {
+        return 'nyholm';
+    }
+}

--- a/Tests/Functional/NyholmControllerTest.php
+++ b/Tests/Functional/NyholmControllerTest.php
@@ -28,6 +28,10 @@ final class NyholmControllerTest extends ControllerTest
 
     protected static function getImplementation(): string
     {
+        if (!class_exists(Psr17Factory::class)) {
+            self::markTestSkipped('This test requires nyholm/psr7.');
+        }
+
         return 'nyholm';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,10 @@
         "symfony/http-foundation": "^4.4 || ^5.0"
     },
     "require-dev": {
+        "laminas/laminas-diactoros": "^2.4",
         "symfony/browser-kit": "^4.4 || ^5.0",
         "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0",
@@ -41,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.1-dev"
+            "dev-main": "2.2-dev"
         }
     }
 }


### PR DESCRIPTION
This is an attempt to support any PSR-17 implementation.

If the user wants to use a `custom` implementation, PSR-17 FQCN services should be defined by the user.